### PR TITLE
Update project_urls.py

### DIFF
--- a/project_urls.py
+++ b/project_urls.py
@@ -54,4 +54,5 @@ project_urls = [
             'https://github.com/aiunderstand/tinytapeout_asyncbinterconvcomp.git',
     #        'https://github.com/smunaut/tinytapeout-fifo',
             'https://github.com/nwtechguy/tinytapeout_BCD_counter',
+            'https://github.com/ericsmi/tinytapeout-verilog-div3.git'
     ]


### PR DESCRIPTION
This is an asynchronous divide by 3. 

One issue with div3 is it requires checking out mpw-7a and OPENLANE_TAG="2022.07.02_01.38.08" due to the combinational feedback paths.  Without those the build will hang at STA so please reject if upgrading is not possible. 

My repo did build though so if you grab the GDS directly it should work. 