### PR TITLE
change scan chain instantiation order

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -238,7 +238,12 @@ class CaravelConfig():
         with open("openlane/user_project_wrapper/macro.cfg", 'w') as fh:
             fh.write("scan_controller 80 80 N\n")
             for row in range(rows):
-                for col in range(cols):
+                if(row%2 == 0):
+                    col_order = range(cols)
+                else:
+                    #reverse odd rows to place instances in a zig zag pattern, shortening the scan chain wires
+                    col_order = range(cols-1, -1, -1)
+                for col in col_order:
                     # skip the space where the scan controller goes on the first row
                     if row == 0 and col <= 1:
                         continue

--- a/configure.py
+++ b/configure.py
@@ -240,9 +240,11 @@ class CaravelConfig():
             for row in range(rows):
                 if(row%2 == 0):
                     col_order = range(cols)
+                    orientation = 'N'
                 else:
                     #reverse odd rows to place instances in a zig zag pattern, shortening the scan chain wires
                     col_order = range(cols-1, -1, -1)
+                    orientation = 'S'
                 for col in col_order:
                     # skip the space where the scan controller goes on the first row
                     if row == 0 and col <= 1:
@@ -250,7 +252,9 @@ class CaravelConfig():
 
                     if num_macros_placed < self.num_projects:
                         macro_instance = self.projects.get_macro_instance(num_macros_placed)
-                        instance = "{} {:<4} {:<4} N\n".format(macro_instance, start_x + col * step_x, start_y + row * step_y)
+                        instance = "{} {:<4} {:<4} {}\n".format(
+                            macro_instance, start_x + col * step_x, start_y + row * step_y, orientation
+                        )
                         fh.write(instance)
 
                     num_macros_placed += 1


### PR DESCRIPTION
Changed the instantiation order to shorten the scan chain wires

mattven: "at the moment it's like #1 and #2 would mean shorter wires between rows"
![PXL_20220902_112741269](https://user-images.githubusercontent.com/8505741/188155162-2e035a24-bafd-4f80-98ac-997e5cf6e8c8.jpg)
